### PR TITLE
converted {% load staticfiles %} to (% load static %} in base.html to support django-3.0 and above

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
I encountered this error when i ran the program, with my django version at 3.0.2.  